### PR TITLE
Fix git "safe directory" config in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,10 +8,11 @@
 	},
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [4000]
+	"forwardPorts": [4000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "ruby --version",
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
Adds the workspace directory to "safe directory" configuration in Git config. Resolves an error produced by git commands because the working directory is not owned by the same user as the parent in the default dev container environment configuration.

https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/