### PR TITLE
Remove added node tooling from vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
 	"name": "Ruby",
 	"image": "mcr.microsoft.com/devcontainers/ruby:3.1-bullseye",
-	"features": {
-		"ghcr.io/devcontainers/features/node:1": {
-			"version": "none"
-		}
-	},
+	// "features": {},
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [4000],


### PR DESCRIPTION
Removes the default "feature" for node development from the Ruby dev container. It's really no needed in this environment - at least not at the moment.

Mostly an experiment in managing this configuration.