### PR TITLE
Add tasks.json for VSCode to launch Jekyll

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Jekyll Serve",
+            "type": "shell",
+            "command": "bundle exec jekyll serve",
+            "isBackground": true
+        },
+        {
+            "label": "Jekyll Serve (drafts)",
+            "type": "shell",
+            "command": "bundle exec jekyll serve --drafts",
+            "isBackground": true
+        },
+        {
+            "label": "Jekyll Serve (watch)",
+            "type": "shell",
+            "command": "bundle exec jekyll serve --watch",
+            "isBackground": true
+        },
+        {
+            "label": "Jekyll Serve (drafts, watch)",
+            "type": "shell",
+            "command": "bundle exec jekyll serve --drafts --watch",
+            "isBackground": true
+        }
+    ]
+}


### PR DESCRIPTION
Adds tasks for:

- Jekyll Serve
- Jekyll Serve (drafts)
- Jekyll Serve (watch)
- Jekyll Serve (drafts, watch)